### PR TITLE
Show locale short code in translation fields

### DIFF
--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -11,8 +11,7 @@
           <% @resource.class.translated_attribute_names.each_with_index do |attr,i| %>
             <tr style="display:<%= i == 0 ? 'auto' : 'none' %>;" class="<%= attr %> <%= locale %> even">
               <td style="padding:4px;" colspan="2">
-                <%= Spree.t(:'i18n.this_file_language', :locale => locale) %> -
-                <%= Spree.t(attr, :locale => locale, scope: [:spree_i18n, :attributes] ) %>
+                <%= Spree.t(:'i18n.this_file_language', :locale => locale) %> (<%= locale %>)
               </td>
             </tr>
             <tr style="display:<%= i == 0 ? 'auto' : 'none' %>;" class="<%= attr %> <%= locale %> odd">


### PR DESCRIPTION
This avoids an annoying issue where there are two Spanish listed with no way to disambiguate between locales `es` and `es-US`.

Asana: https://app.asana.com/0/319353371374559/285021090791477

Screenshot of result:
![image](https://cloud.githubusercontent.com/assets/148820/25227983/333ee18e-25d3-11e7-92cd-291cec9c8d3d.png)
